### PR TITLE
accept square brackets for query parameters

### DIFF
--- a/tomcat/server.xml
+++ b/tomcat/server.xml
@@ -73,6 +73,7 @@
                redirectPort="8443"
                proxyPort="443"
                scheme="https"
+               relaxedQueryChars='[]'
     />
     <!-- A "Connector" using the shared thread pool-->
     <!--


### PR DESCRIPTION
Fix Tomcat not accepting square brackets in query parameters